### PR TITLE
Add grouping to renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,10 +15,7 @@
     {
       "packageNames": ["jest"],
       "groupName": "testing packages",
-      "automerge": true,
-      "major": {
-        "automerge": false
-      }
+      "automerge": true
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,24 @@
 {
   "extends": ["config:base"],
   "prHourlyLimit": 0,
-  "rebaseStalePrs": true
+  "rebaseStalePrs": true,
+  "packageRules": [
+    {
+      "packageNames": ["husky", "lint-staged", "prettier"],
+      "packagePatterns": ["^eslint"],
+      "groupName": "linting packages",
+      "automerge": true,
+      "major": {
+        "automerge": false
+      }
+    },
+    {
+      "packageNames": ["jest"],
+      "groupName": "testing packages",
+      "automerge": true,
+      "major": {
+        "automerge": false
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Group dependencies in Renovate config and setup automerge rules.