### PR TITLE
Force CORS header to wildcard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2228,7 +2228,7 @@
       "dependencies": {
         "callsites": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
           "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
           "dev": true
         }
@@ -3941,8 +3941,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3963,14 +3962,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3985,20 +3982,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4115,8 +4109,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4128,7 +4121,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4143,7 +4135,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4151,14 +4142,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4177,7 +4166,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4258,8 +4246,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4271,7 +4258,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4357,8 +4343,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4394,7 +4379,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4414,7 +4398,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4458,14 +4441,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -6662,11 +6643,6 @@
           }
         }
       }
-    },
-    "koa-cors": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/koa-cors/-/koa-cors-0.0.16.tgz",
-      "integrity": "sha1-mBB5k6eQnjTAQphsXsYVbXfzQy4="
     },
     "koa-etag": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "koa": "2.7.0",
     "koa-combine-routers": "4.0.2",
     "koa-compress": "3.0.0",
-    "koa-cors": "0.0.16",
     "koa-etag": "3.0.0",
     "koa-helmet": "4.0.0",
     "koa-logger": "3.2.0",

--- a/src/app/middleware/cors.js
+++ b/src/app/middleware/cors.js
@@ -1,0 +1,8 @@
+const createMiddleware = () => async (context, next) => {
+  context.set('Access-Control-Allow-Origin', '*');
+  context.set('Access-Control-Allow-Methods', 'GET,HEAD,PUT,POST,DELETE');
+
+  await next();
+};
+
+module.exports = createMiddleware;

--- a/src/app/start.js
+++ b/src/app/start.js
@@ -1,12 +1,12 @@
 const compress = require('koa-compress');
 const consoleLogger = require('koa-logger');
-const cors = require('koa-cors');
 const etag = require('koa-etag');
 const helmet = require('koa-helmet');
 const Koa = require('koa');
 const signale = require('signale');
 
 const cacheControl = require('./middleware/cache-control');
+const cors = require('./middleware/cors');
 const error = require('./middleware/error');
 const errorLogger = require('../util/error-logger');
 const invalidUrl = require('./middleware/invalid-url');


### PR DESCRIPTION
# Description

This PR fixes CORS issues related to Cloudfront which was caching the CORS header as origin. 

When viewing branch deploys, Cloudfront would cached the Access-Control-Allow-Origin header as the branch deploy url, rather than 0xtracker.com. This would cause fetch errors on 0xtracker.com. The Access-Control-Allow-Origin header is now forced to *.