### PR TITLE
Ensure ID field is output by relayer endpoint

### DIFF
--- a/src/app/routes/v2/util/transform-relayer.js
+++ b/src/app/routes/v2/util/transform-relayer.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 
 const transformRelayer = relayer => {
-  return _.pick(relayer, ['imageUrl', 'name', 'slug', 'stats', 'url']);
+  return _.pick(relayer, ['id', 'imageUrl', 'name', 'slug', 'stats', 'url']);
 };
 
 module.exports = transformRelayer;


### PR DESCRIPTION
# Description

This PR ensures that the relayer endpoint (`/relayers/{slug}`) outputs a relayer ID. Not outputting one caused an issue on the relayer page when listing fills associated with the relayer.