### PR TITLE
Deprecate maker/taker amount/token fields

### DIFF
--- a/src/app/routes/v1/util/__snapshots__/transform-fill.test.js.snap
+++ b/src/app/routes/v1/util/__snapshots__/transform-fill.test.js.snap
@@ -51,18 +51,12 @@ Object {
   "feeRecipient": "0xe269e891a2ec8585a378882ffa531141205e92e9",
   "id": "5b9107e00d05f400042e3494",
   "makerAddress": "0x8dd688660ec0babd0b8a2f2de3232645f73cc5eb",
-  "makerAmount": "7.1373405",
   "makerFee": Object {
     "USD": 9.13,
     "ZRX": "15",
   },
   "makerPrice": Object {
     "USD": 224.42000000000002,
-  },
-  "makerToken": Object {
-    "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
-    "name": "Wrapped Ether",
-    "symbol": "WETH",
   },
   "orderHash": "0xd7cbdddb68cfa6216e867227a4cb8ca281e0d82921000b4b977d6038535482f5",
   "protocolVersion": 1,
@@ -74,18 +68,12 @@ Object {
   "senderAddress": undefined,
   "status": "successful",
   "takerAddress": "0xe269e891a2ec8585a378882ffa531141205e92e9",
-  "takerAmount": "300000",
   "takerFee": Object {
     "USD": 3.04,
     "ZRX": "5",
   },
   "takerPrice": Object {
     "USD": 0.0053392065167000005,
-  },
-  "takerToken": Object {
-    "address": "0xd7732e3783b0047aa251928960063f863ad022d8",
-    "name": "BrahmaOS",
-    "symbol": "BRM",
   },
   "totalFees": Object {
     "USD": 12.170000000000002,
@@ -95,6 +83,28 @@ Object {
   "value": Object {
     "USD": 1601.76195501,
   },
+}
+`;
+
+exports[`transformFill should transform V1 fill with unrecognised maker token 1`] = `
+Object {
+  "amount": null,
+  "tokenAddress": "0x1234",
+  "tokenSymbol": undefined,
+  "tokenType": undefined,
+  "traderType": "maker",
+  "type": "erc-20",
+}
+`;
+
+exports[`transformFill should transform V1 fill with unrecognised taker token 1`] = `
+Object {
+  "amount": null,
+  "tokenAddress": "0x9999",
+  "tokenSymbol": undefined,
+  "tokenType": undefined,
+  "traderType": "taker",
+  "type": "erc-20",
 }
 `;
 
@@ -127,18 +137,12 @@ Object {
   "feeRecipient": "0xe269e891a2ec8585a378882ffa531141205e92e9",
   "id": "5b9107e00d05f400042e3494",
   "makerAddress": "0x8dd688660ec0babd0b8a2f2de3232645f73cc5eb",
-  "makerAmount": "1",
   "makerFee": Object {
     "USD": 0,
     "ZRX": "15",
   },
   "makerPrice": Object {
     "USD": 37.77675,
-  },
-  "makerToken": Object {
-    "address": "0xf5b0a3efb8e8e4c201e2a935f110eaaf3ffecb8d",
-    "name": "Axie",
-    "symbol": "AXIE",
   },
   "orderHash": "0xd7cbdddb68cfa6216e867227a4cb8ca281e0d82921000b4b977d6038535482f5",
   "protocolVersion": 1,
@@ -150,18 +154,12 @@ Object {
   "senderAddress": undefined,
   "status": "successful",
   "takerAddress": "0xe269e891a2ec8585a378882ffa531141205e92e9",
-  "takerAmount": "0.275",
   "takerFee": Object {
     "USD": 0,
     "ZRX": "5",
   },
   "takerPrice": Object {
     "USD": 137.36999999999998,
-  },
-  "takerToken": Object {
-    "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
-    "name": "Wrapped Ether",
-    "symbol": "WETH",
   },
   "totalFees": Object {
     "USD": 0,

--- a/src/app/routes/v1/util/transform-fill.js
+++ b/src/app/routes/v1/util/transform-fill.js
@@ -1,34 +1,17 @@
 const _ = require('lodash');
 
-const {
-  FILL_STATUS,
-  TRADER_TYPE,
-  ZRX_TOKEN_ADDRESS,
-} = require('../../../../constants');
+const { FILL_STATUS, ZRX_TOKEN_ADDRESS } = require('../../../../constants');
 const formatTokenAmount = require('../../../../tokens/format-token-amount');
 const getAssetsForFill = require('../../../../fills/get-assets-for-fill');
 
 const formatRelayer = relayer =>
   relayer === undefined ? null : _.pick(relayer, 'slug', 'name', 'imageUrl');
 
-const formatToken = token =>
-  _.isString(token)
-    ? { address: token }
-    : {
-        address: token.address,
-        name: token.name,
-        symbol: token.symbol,
-      };
-
 const formatFillStatus = status =>
   _.findKey(FILL_STATUS, value => status === value).toLowerCase();
 
 const transformFill = (tokens, relayers, fill) => {
   const assets = getAssetsForFill(tokens, fill);
-  const makerAsset = _.find(assets, { traderType: TRADER_TYPE.MAKER });
-  const takerAsset = _.find(assets, { traderType: TRADER_TYPE.TAKER });
-  const makerToken = tokens[makerAsset.tokenAddress] || makerAsset.tokenAddress;
-  const takerToken = tokens[takerAsset.tokenAddress] || takerAsset.tokenAddress;
   const conversions = _.get(fill, `conversions.USD`);
   const fillRelayer = _.find(relayers, { lookupId: fill.relayerId });
   const zrxToken = tokens[ZRX_TOKEN_ADDRESS];
@@ -57,24 +40,20 @@ const transformFill = (tokens, relayers, fill) => {
     feeRecipient: fill.feeRecipient,
     id: fill.id,
     makerAddress: fill.maker,
-    makerAmount: formatTokenAmount(fill.makerAmount, makerToken), // TODO: Deprecate in favor of assets
     makerFee,
     makerPrice: {
       USD: _.get(conversions, 'makerPrice'),
     },
-    makerToken: formatToken(makerToken), // TODO: Deprecate in favor of assets
     orderHash: fill.orderHash,
     protocolVersion: fill.protocolVersion,
     relayer: formatRelayer(fillRelayer),
     senderAddress: fill.senderAddress,
     status: formatFillStatus(fill.status),
     takerAddress: fill.taker,
-    takerAmount: formatTokenAmount(fill.takerAmount, takerToken), // TODO: Deprecate in favor of assets
     takerFee,
     takerPrice: {
       USD: _.get(conversions, 'takerPrice'),
     },
-    takerToken: formatToken(takerToken), // TODO: Deprecate in favor of assets
     totalFees,
     transactionHash: fill.transactionHash,
     value: {

--- a/src/app/routes/v1/util/transform-fill.test.js
+++ b/src/app/routes/v1/util/transform-fill.test.js
@@ -110,18 +110,18 @@ describe('transformFill', () => {
     const fill = { ...simpleV1Fill, makerToken: '0x1234' };
     const viewModel = transformFill(tokens, relayers, fill);
 
-    expect(viewModel.makerToken).toEqual({
-      address: '0x1234',
-    });
+    expect(
+      viewModel.assets.find(asset => asset.traderType === 'maker'),
+    ).toMatchSnapshot();
   });
 
   it('should transform V1 fill with unrecognised taker token', () => {
     const fill = { ...simpleV1Fill, takerToken: '0x9999' };
     const viewModel = transformFill(tokens, relayers, fill);
 
-    expect(viewModel.takerToken).toEqual({
-      address: '0x9999',
-    });
+    expect(
+      viewModel.assets.find(asset => asset.traderType === 'taker'),
+    ).toMatchSnapshot();
   });
 
   it('should transform fill with unrecognised relayer', () => {


### PR DESCRIPTION
# What does this PR do?

This PR removes the makerAmount, makerToken, takerAmount, and takerToken fields from fills endpoints. This is part of a larger initiative to support multi-asset fills.