### PR TITLE
Add price to assets on fills endpoints

### DIFF
--- a/src/app/routes/v1/util/__snapshots__/transform-fill.test.js.snap
+++ b/src/app/routes/v1/util/__snapshots__/transform-fill.test.js.snap
@@ -3,6 +3,9 @@
 exports[`transformFill should transform ERC20 asset 1`] = `
 Object {
   "amount": "0.275",
+  "price": Object {
+    "USD": 137.36999999999998,
+  },
   "tokenAddress": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
   "tokenId": undefined,
   "tokenSymbol": "WETH",
@@ -15,6 +18,9 @@ Object {
 exports[`transformFill should transform ERC721 asset 1`] = `
 Object {
   "amount": "1",
+  "price": Object {
+    "USD": 37.77675,
+  },
   "tokenAddress": "0xf5b0a3efb8e8e4c201e2a935f110eaaf3ffecb8d",
   "tokenId": 43381,
   "tokenSymbol": "AXIE",
@@ -32,6 +38,9 @@ Object {
   "assets": Array [
     Object {
       "amount": "300000",
+      "price": Object {
+        "USD": 0.0053392065167000005,
+      },
       "tokenAddress": "0xd7732e3783b0047aa251928960063f863ad022d8",
       "tokenSymbol": "BRM",
       "tokenType": "BrahmaOS",
@@ -40,6 +49,9 @@ Object {
     },
     Object {
       "amount": "7.1373405",
+      "price": Object {
+        "USD": 224.42000000000002,
+      },
       "tokenAddress": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
       "tokenSymbol": "WETH",
       "tokenType": "Wrapped Ether",
@@ -89,6 +101,9 @@ Object {
 exports[`transformFill should transform V1 fill with unrecognised maker token 1`] = `
 Object {
   "amount": null,
+  "price": Object {
+    "USD": 224.42000000000002,
+  },
   "tokenAddress": "0x1234",
   "tokenSymbol": undefined,
   "tokenType": undefined,
@@ -100,6 +115,9 @@ Object {
 exports[`transformFill should transform V1 fill with unrecognised taker token 1`] = `
 Object {
   "amount": null,
+  "price": Object {
+    "USD": 0.0053392065167000005,
+  },
   "tokenAddress": "0x9999",
   "tokenSymbol": undefined,
   "tokenType": undefined,
@@ -116,6 +134,9 @@ Object {
   "assets": Array [
     Object {
       "amount": "1",
+      "price": Object {
+        "USD": 37.77675,
+      },
       "tokenAddress": "0xf5b0a3efb8e8e4c201e2a935f110eaaf3ffecb8d",
       "tokenId": 43381,
       "tokenSymbol": "AXIE",
@@ -125,6 +146,9 @@ Object {
     },
     Object {
       "amount": "0.275",
+      "price": Object {
+        "USD": 137.36999999999998,
+      },
       "tokenAddress": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
       "tokenId": undefined,
       "tokenSymbol": "WETH",
@@ -145,7 +169,7 @@ Object {
     "USD": 37.77675,
   },
   "orderHash": "0xd7cbdddb68cfa6216e867227a4cb8ca281e0d82921000b4b977d6038535482f5",
-  "protocolVersion": 1,
+  "protocolVersion": 2,
   "relayer": Object {
     "imageUrl": "https://0xtracker.com/assets/logos/ethfinex.png",
     "name": "Ethfinex",
@@ -175,6 +199,9 @@ Object {
 exports[`transformFill should transform fill with unknown maker asset 1`] = `
 Object {
   "amount": null,
+  "price": Object {
+    "USD": 37.77675,
+  },
   "tokenAddress": "0x12345",
   "tokenId": 43381,
   "tokenSymbol": undefined,
@@ -187,6 +214,9 @@ Object {
 exports[`transformFill should transform fill with unknown taker asset 1`] = `
 Object {
   "amount": null,
+  "price": Object {
+    "USD": 137.36999999999998,
+  },
   "tokenAddress": "0x12345",
   "tokenId": undefined,
   "tokenSymbol": undefined,

--- a/src/app/routes/v1/util/transform-fill.js
+++ b/src/app/routes/v1/util/transform-fill.js
@@ -32,9 +32,11 @@ const transformFill = (tokens, relayers, fill) => {
   };
 
   return {
-    amount: {
-      USD: _.get(fill, `conversions.USD.amount`),
-    },
+    amount: _.has(fill, `conversions.USD.amount`)
+      ? {
+          USD: _.get(fill, `conversions.USD.amount`),
+        }
+      : undefined,
     assets,
     date: fill.date,
     feeRecipient: fill.feeRecipient,
@@ -56,9 +58,11 @@ const transformFill = (tokens, relayers, fill) => {
     },
     totalFees,
     transactionHash: fill.transactionHash,
-    value: {
-      USD: _.get(fill, `conversions.USD.amount`),
-    },
+    value: _.has(fill, `conversions.USD.amount`)
+      ? {
+          USD: _.get(fill, `conversions.USD.amount`),
+        }
+      : undefined,
   };
 };
 

--- a/src/app/routes/v1/util/transform-fill.test.js
+++ b/src/app/routes/v1/util/transform-fill.test.js
@@ -43,7 +43,7 @@ const simpleFill = {
   makerFee: 15000000000000000000,
   orderHash:
     '0xd7cbdddb68cfa6216e867227a4cb8ca281e0d82921000b4b977d6038535482f5',
-  protocolVersion: 1,
+  protocolVersion: 2,
   relayerId: 21,
   roundedDates: {
     day: '2018-09-06T00:00:00.000Z',
@@ -73,6 +73,7 @@ const simpleV1Fill = {
   makerAmount: 7137340500000000000,
   makerAsset: undefined,
   makerToken: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+  protocolVersion: 1,
   prices: { maker: 42032.46293209634, taker: 0.000023791135, saved: true },
   rates: {
     data: { ZRX: { USD: 0.6085 }, ETH: { USD: 224.42 } },

--- a/src/fills/get-assets-for-fill.js
+++ b/src/fills/get-assets-for-fill.js
@@ -12,10 +12,20 @@ const formatTokenAmount = require('../tokens/format-token-amount');
 const createAsset = (tokens, fill, tokenAddress, traderType) => {
   const amount =
     traderType === TRADER_TYPE.MAKER ? fill.makerAmount : fill.takerAmount;
+  const price =
+    traderType === TRADER_TYPE.MAKER
+      ? _.get(fill, 'conversions.USD.makerPrice')
+      : _.get(fill, 'conversions.USD.takerPrice');
   const token = tokens[tokenAddress];
 
   return {
     amount: amount !== undefined ? formatTokenAmount(amount, token) : undefined,
+    price:
+      price !== undefined
+        ? {
+            USD: price,
+          }
+        : undefined,
     tokenAddress,
     tokenSymbol: _.get(token, 'symbol'),
     tokenType: _.get(token, 'name'),
@@ -28,10 +38,20 @@ const createAsset = (tokens, fill, tokenAddress, traderType) => {
 const transformAsset = (tokens, fill, asset, traderType) => {
   const amount =
     traderType === TRADER_TYPE.MAKER ? fill.makerAmount : fill.takerAmount;
+  const price =
+    traderType === TRADER_TYPE.MAKER
+      ? _.get(fill, 'conversions.USD.makerPrice')
+      : _.get(fill, 'conversions.USD.takerPrice');
   const token = tokens[asset.tokenAddress];
 
   return {
     amount: amount !== undefined ? formatTokenAmount(amount, token) : undefined,
+    price:
+      price !== undefined
+        ? {
+            USD: price,
+          }
+        : undefined,
     tokenAddress: asset.tokenAddress,
     tokenId: asset.tokenId,
     tokenSymbol: _.get(token, 'symbol'),
@@ -44,7 +64,7 @@ const transformAsset = (tokens, fill, asset, traderType) => {
 const getAssetsForFill = (tokens, fill) => {
   const assets = [];
 
-  if (_.get(fill, 'makerAsset.tokenAddress') !== undefined) {
+  if (fill.protocolVersion === 2) {
     assets.push(
       transformAsset(tokens, fill, fill.makerAsset, TRADER_TYPE.MAKER),
       transformAsset(tokens, fill, fill.takerAsset, TRADER_TYPE.TAKER),


### PR DESCRIPTION
# Description

This PR adds prices to assets on the fills endpoints, providing better groundwork for multi-asset fills. This change deprecates makerPrice and takerPrice fields, which will be removed in a future PR.