### PR TITLE
Fix 24h network stats

### DIFF
--- a/src/stats/compute-24-hour-network-stats.js
+++ b/src/stats/compute-24-hour-network-stats.js
@@ -12,7 +12,10 @@ const compute24HourNetworkStats = async () => {
 
   const baseQuery = {
     date: {
-      $gte: dateFrom,
+      $gte: moment
+        .utc(dateFrom)
+        .startOf('day')
+        .toDate(),
       $lte: dateTo,
     },
   };


### PR DESCRIPTION
# Description

24 hour network stats are incorrectly being reported, using just today's stats instead of the last 24 hours. This PR implements a fix, ensuring that the last 24 hours of fills are accounted for.