### PR TITLE
Consume assets field

### DIFF
--- a/src/app/routes/v1/util/__snapshots__/transform-fill.test.js.snap
+++ b/src/app/routes/v1/util/__snapshots__/transform-fill.test.js.snap
@@ -34,25 +34,27 @@ exports[`transformFill should transform V1 fill 1`] = `
 Object {
   "assets": Array [
     Object {
-      "amount": "300000",
-      "price": Object {
-        "USD": 0.0053392065167000005,
-      },
-      "tokenAddress": "0xd7732e3783b0047aa251928960063f863ad022d8",
-      "tokenSymbol": "BRM",
-      "tokenType": "BrahmaOS",
-      "traderType": "taker",
-      "type": "erc-20",
-    },
-    Object {
       "amount": "7.1373405",
       "price": Object {
         "USD": 224.42000000000002,
       },
       "tokenAddress": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+      "tokenId": undefined,
       "tokenSymbol": "WETH",
       "tokenType": "Wrapped Ether",
       "traderType": "maker",
+      "type": "erc-20",
+    },
+    Object {
+      "amount": "300000",
+      "price": Object {
+        "USD": 0.0053392065167000005,
+      },
+      "tokenAddress": "0xd7732e3783b0047aa251928960063f863ad022d8",
+      "tokenId": undefined,
+      "tokenSymbol": "BRM",
+      "tokenType": "BrahmaOS",
+      "traderType": "taker",
       "type": "erc-20",
     },
   ],
@@ -89,31 +91,33 @@ Object {
 }
 `;
 
-exports[`transformFill should transform V1 fill with unrecognised maker token 1`] = `
+exports[`transformFill should transform V1 fill with unrecognised maker asset 1`] = `
 Object {
   "amount": null,
   "price": Object {
     "USD": 224.42000000000002,
   },
   "tokenAddress": "0x1234",
+  "tokenId": undefined,
   "tokenSymbol": undefined,
   "tokenType": undefined,
   "traderType": "maker",
-  "type": "erc-20",
+  "type": undefined,
 }
 `;
 
-exports[`transformFill should transform V1 fill with unrecognised taker token 1`] = `
+exports[`transformFill should transform V1 fill with unrecognised taker asset 1`] = `
 Object {
   "amount": null,
   "price": Object {
     "USD": 0.0053392065167000005,
   },
   "tokenAddress": "0x9999",
+  "tokenId": undefined,
   "tokenSymbol": undefined,
   "tokenType": undefined,
   "traderType": "taker",
-  "type": "erc-20",
+  "type": undefined,
 }
 `;
 
@@ -175,35 +179,5 @@ Object {
   "value": Object {
     "USD": 37.77675,
   },
-}
-`;
-
-exports[`transformFill should transform fill with unknown maker asset 1`] = `
-Object {
-  "amount": null,
-  "price": Object {
-    "USD": 37.77675,
-  },
-  "tokenAddress": "0x12345",
-  "tokenId": 43381,
-  "tokenSymbol": undefined,
-  "tokenType": undefined,
-  "traderType": "maker",
-  "type": "erc-721",
-}
-`;
-
-exports[`transformFill should transform fill with unknown taker asset 1`] = `
-Object {
-  "amount": null,
-  "price": Object {
-    "USD": 137.36999999999998,
-  },
-  "tokenAddress": "0x12345",
-  "tokenId": undefined,
-  "tokenSymbol": undefined,
-  "tokenType": undefined,
-  "traderType": "taker",
-  "type": "erc-20",
 }
 `;

--- a/src/app/routes/v1/util/transform-fill.test.js
+++ b/src/app/routes/v1/util/transform-fill.test.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 
+const { FILL_ACTOR } = require('../../../../constants');
 const AXIE_FIXTURE = require('../../../../fixtures/tokens/axie');
 const BRAHMA_FIXTURE = require('../../../../fixtures/tokens/brahma');
 const ETHFINEX_FIXTURE = require('../../../../fixtures/relayers/ethfinex');
@@ -8,7 +9,43 @@ const ZRX_FIXTURE = require('../../../../fixtures/tokens/zrx');
 
 const transformFill = require('./transform-fill');
 
+const axieMaker = {
+  actor: FILL_ACTOR.MAKER,
+  amount: 1,
+  price: {
+    USD: 37.77675,
+  },
+  tokenAddress: '0xf5b0a3efb8e8e4c201e2a935f110eaaf3ffecb8d',
+  tokenId: 43381,
+};
+
+const wethTaker = {
+  actor: FILL_ACTOR.TAKER,
+  amount: 275000000000000000,
+  price: {
+    USD: 137.36999999999998,
+  },
+  tokenAddress: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+};
+
+const brahmaTaker = {
+  actor: FILL_ACTOR.TAKER,
+  amount: 3e23,
+  price: { USD: 0.0053392065167000005 },
+  tokenAddress: '0xd7732e3783b0047aa251928960063f863ad022d8',
+};
+
+const wethMaker = {
+  actor: FILL_ACTOR.MAKER,
+  amount: 7137340500000000000,
+  price: {
+    USD: 224.42000000000002,
+  },
+  tokenAddress: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+};
+
 const simpleFill = {
+  assets: [axieMaker, wethTaker],
   id: '5b9107e00d05f400042e3494',
   conversions: {
     USD: {
@@ -34,6 +71,7 @@ const simpleFill = {
 
 const simpleV1Fill = {
   ...simpleFill,
+  assets: [wethMaker, brahmaTaker],
   conversions: {
     USD: {
       amount: 1601.76195501,
@@ -67,8 +105,11 @@ describe('transformFill', () => {
     expect(viewModel.relayer).toBeNull();
   });
 
-  it('should transform V1 fill with unrecognised maker token', () => {
-    const fill = { ...simpleV1Fill };
+  it('should transform V1 fill with unrecognised maker asset', () => {
+    const fill = {
+      ...simpleV1Fill,
+      assets: [{ ...wethMaker, tokenAddress: '0x1234' }, brahmaTaker],
+    };
     const viewModel = transformFill(tokens, relayers, fill);
 
     expect(
@@ -76,8 +117,11 @@ describe('transformFill', () => {
     ).toMatchSnapshot();
   });
 
-  it('should transform V1 fill with unrecognised taker token', () => {
-    const fill = { ...simpleV1Fill };
+  it('should transform V1 fill with unrecognised taker asset', () => {
+    const fill = {
+      ...simpleV1Fill,
+      assets: [wethMaker, { ...brahmaTaker, tokenAddress: '0x9999' }],
+    };
     const viewModel = transformFill(tokens, relayers, fill);
 
     expect(
@@ -116,26 +160,6 @@ describe('transformFill', () => {
     const viewModel = transformFill(tokens, relayers, simpleFill);
 
     expect(viewModel).toMatchSnapshot();
-  });
-
-  it('should transform fill with unknown maker asset', () => {
-    const viewModel = transformFill(tokens, relayers, {
-      ...simpleFill,
-    });
-
-    const asset = _.find(viewModel.assets, { traderType: 'maker' });
-
-    expect(asset).toMatchSnapshot();
-  });
-
-  it('should transform fill with unknown taker asset', () => {
-    const viewModel = transformFill(tokens, relayers, {
-      ...simpleFill,
-    });
-
-    const asset = _.find(viewModel.assets, { traderType: 'taker' });
-
-    expect(asset).toMatchSnapshot();
   });
 
   it('should transform ERC721 asset', () => {

--- a/src/app/routes/v1/util/transform-fill.test.js
+++ b/src/app/routes/v1/util/transform-fill.test.js
@@ -10,27 +10,11 @@ const transformFill = require('./transform-fill');
 
 const simpleFill = {
   id: '5b9107e00d05f400042e3494',
-  prices: { maker: 0.275, taker: 3.6363636363636362, saved: true },
-  makerAmount: 1,
-  makerAsset: {
-    assetProxyId: '0x02571792',
-    tokenAddress: '0xf5b0a3efb8e8e4c201e2a935f110eaaf3ffecb8d',
-    tokenId: 43381,
-  },
-  makerToken: '0xf5b0a3efb8e8e4c201e2a935f110eaaf3ffecb8d',
-  takerAmount: 275000000000000000,
-  takerAsset: {
-    assetProxyId: '0xf47261b0',
-    tokenAddress: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
-  },
-  takerToken: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
   conversions: {
     USD: {
       amount: 37.77675,
       makerFee: 0,
       takerFee: 0,
-      makerPrice: 37.77675,
-      takerPrice: 137.36999999999998,
     },
   },
   date: '2018-09-06T10:47:38.000Z',
@@ -44,7 +28,6 @@ const simpleFill = {
   status: 1,
   taker: '0xe269e891a2ec8585a378882ffa531141205e92e9',
   takerFee: 5000000000000000000,
-  tokenSaved: { maker: true, taker: true },
   transactionHash:
     '0x4c69e925be055eec7bc49cc681fd5267d1aca7e1db21f687ab19ab9d75b7447c',
 };
@@ -56,22 +39,9 @@ const simpleV1Fill = {
       amount: 1601.76195501,
       makerFee: 9.13,
       takerFee: 3.04,
-      makerPrice: 224.42000000000002,
-      takerPrice: 0.0053392065167000005,
     },
   },
-  makerAmount: 7137340500000000000,
-  makerAsset: undefined,
-  makerToken: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
   protocolVersion: 1,
-  prices: { maker: 42032.46293209634, taker: 0.000023791135, saved: true },
-  rates: {
-    data: { ZRX: { USD: 0.6085 }, ETH: { USD: 224.42 } },
-    saved: true,
-  },
-  takerAmount: 3e23,
-  takerAsset: undefined,
-  takerToken: '0xd7732e3783b0047aa251928960063f863ad022d8',
 };
 
 const tokens = {
@@ -98,7 +68,7 @@ describe('transformFill', () => {
   });
 
   it('should transform V1 fill with unrecognised maker token', () => {
-    const fill = { ...simpleV1Fill, makerToken: '0x1234' };
+    const fill = { ...simpleV1Fill };
     const viewModel = transformFill(tokens, relayers, fill);
 
     expect(
@@ -107,7 +77,7 @@ describe('transformFill', () => {
   });
 
   it('should transform V1 fill with unrecognised taker token', () => {
-    const fill = { ...simpleV1Fill, takerToken: '0x9999' };
+    const fill = { ...simpleV1Fill };
     const viewModel = transformFill(tokens, relayers, fill);
 
     expect(
@@ -151,11 +121,6 @@ describe('transformFill', () => {
   it('should transform fill with unknown maker asset', () => {
     const viewModel = transformFill(tokens, relayers, {
       ...simpleFill,
-      makerAsset: {
-        assetProxyId: '0x02571792',
-        tokenAddress: '0x12345',
-        tokenId: 43381,
-      },
     });
 
     const asset = _.find(viewModel.assets, { traderType: 'maker' });
@@ -166,10 +131,6 @@ describe('transformFill', () => {
   it('should transform fill with unknown taker asset', () => {
     const viewModel = transformFill(tokens, relayers, {
       ...simpleFill,
-      takerAsset: {
-        assetProxyId: '0xf47261b0',
-        tokenAddress: '0x12345',
-      },
     });
 
     const asset = _.find(viewModel.assets, { traderType: 'taker' });

--- a/src/constants.js
+++ b/src/constants.js
@@ -15,6 +15,10 @@ module.exports = {
     MAKER: 0,
     TAKER: 1,
   },
+  TOKEN_TYPE: {
+    ERC20: 0,
+    ERC721: 1,
+  },
   TRADER_TYPE: {
     MAKER: 'maker',
     TAKER: 'taker',

--- a/src/constants.js
+++ b/src/constants.js
@@ -11,6 +11,10 @@ module.exports = {
     [AssetProxyId.ERC20]: ASSET_TYPE.ERC20,
     [AssetProxyId.ERC721]: ASSET_TYPE.ERC721,
   },
+  FILL_ACTOR: {
+    MAKER: 0,
+    TAKER: 1,
+  },
   TRADER_TYPE: {
     MAKER: 'maker',
     TAKER: 'taker',

--- a/src/fills/get-assets-for-fill.js
+++ b/src/fills/get-assets-for-fill.js
@@ -1,21 +1,27 @@
 const _ = require('lodash');
 
-const { ASSET_TYPE, FILL_ACTOR, TRADER_TYPE } = require('../constants');
+const { FILL_ACTOR, TOKEN_TYPE, TRADER_TYPE } = require('../constants');
 const formatTokenAmount = require('../tokens/format-token-amount');
+
+const TOKEN_TYPE_LABELS = {
+  [TOKEN_TYPE.ERC20]: 'erc-20',
+  [TOKEN_TYPE.ERC721]: 'erc-721',
+};
 
 const transformAsset = (tokens, asset) => {
   const token = tokens[asset.tokenAddress];
+  const price = _.get(asset.price, 'USD');
 
   return {
     amount: formatTokenAmount(asset.amount, token),
-    price: asset.price,
+    price: _.isNumber(price) ? { USD: price } : undefined,
     tokenAddress: asset.tokenAddress,
     tokenId: asset.tokenId,
     tokenSymbol: _.get(token, 'symbol'),
     tokenType: _.get(token, 'name'),
     traderType:
       asset.actor === FILL_ACTOR.MAKER ? TRADER_TYPE.MAKER : TRADER_TYPE.TAKER,
-    type: ASSET_TYPE.ERC20, // TODO: Store against tokens so this value can be looked up
+    type: TOKEN_TYPE_LABELS[_.get(token, 'type')],
   };
 };
 

--- a/src/fills/get-assets-for-fill.js
+++ b/src/fills/get-assets-for-fill.js
@@ -1,84 +1,28 @@
 const _ = require('lodash');
 
-const {
-  ASSET_TYPE,
-  ASSET_TYPE_BY_PROXY,
-  TRADER_TYPE,
-} = require('../constants');
+const { ASSET_TYPE, FILL_ACTOR, TRADER_TYPE } = require('../constants');
 const formatTokenAmount = require('../tokens/format-token-amount');
 
-// Creates an asset for the given token address and trader type.
-// Only applies to fills from 0x v1.
-const createAsset = (tokens, fill, tokenAddress, traderType) => {
-  const amount =
-    traderType === TRADER_TYPE.MAKER ? fill.makerAmount : fill.takerAmount;
-  const price =
-    traderType === TRADER_TYPE.MAKER
-      ? _.get(fill, 'conversions.USD.makerPrice')
-      : _.get(fill, 'conversions.USD.takerPrice');
-  const token = tokens[tokenAddress];
-
-  return {
-    amount: amount !== undefined ? formatTokenAmount(amount, token) : undefined,
-    price:
-      price !== undefined
-        ? {
-            USD: price,
-          }
-        : undefined,
-    tokenAddress,
-    tokenSymbol: _.get(token, 'symbol'),
-    tokenType: _.get(token, 'name'),
-    traderType,
-    type: ASSET_TYPE.ERC20,
-  };
-};
-
-// Transforms a given 0x asset into our preferred shape
-const transformAsset = (tokens, fill, asset, traderType) => {
-  const amount =
-    traderType === TRADER_TYPE.MAKER ? fill.makerAmount : fill.takerAmount;
-  const price =
-    traderType === TRADER_TYPE.MAKER
-      ? _.get(fill, 'conversions.USD.makerPrice')
-      : _.get(fill, 'conversions.USD.takerPrice');
+const transformAsset = (tokens, asset) => {
   const token = tokens[asset.tokenAddress];
 
   return {
-    amount: amount !== undefined ? formatTokenAmount(amount, token) : undefined,
-    price:
-      price !== undefined
-        ? {
-            USD: price,
-          }
-        : undefined,
+    amount: formatTokenAmount(asset.amount, token),
+    price: asset.price,
     tokenAddress: asset.tokenAddress,
     tokenId: asset.tokenId,
     tokenSymbol: _.get(token, 'symbol'),
     tokenType: _.get(token, 'name'),
-    traderType,
-    type: ASSET_TYPE_BY_PROXY[asset.assetProxyId],
+    traderType:
+      asset.actor === FILL_ACTOR.MAKER ? TRADER_TYPE.MAKER : TRADER_TYPE.TAKER,
+    type: ASSET_TYPE.ERC20, // TODO: Store against tokens so this value can be looked up
   };
 };
 
 const getAssetsForFill = (tokens, fill) => {
-  const assets = [];
+  const mapAsset = _.partial(transformAsset, tokens);
 
-  if (fill.protocolVersion === 2) {
-    assets.push(
-      transformAsset(tokens, fill, fill.makerAsset, TRADER_TYPE.MAKER),
-      transformAsset(tokens, fill, fill.takerAsset, TRADER_TYPE.TAKER),
-    );
-  } else {
-    // Before 0x v2, fills would have a makerToken and takerToken field. Therefore
-    // we need to support that legacy data structure.
-    assets.push(
-      createAsset(tokens, fill, fill.takerToken, TRADER_TYPE.TAKER),
-      createAsset(tokens, fill, fill.makerToken, TRADER_TYPE.MAKER),
-    );
-  }
-
-  return assets;
+  return _.map(fill.assets, mapAsset);
 };
 
 module.exports = getAssetsForFill;

--- a/src/fills/search-fills.js
+++ b/src/fills/search-fills.js
@@ -18,7 +18,7 @@ const searchFills = ({ address, limit, page, query, relayerId, token }) => {
     };
   } else if (_.isString(token)) {
     filter = {
-      $or: [{ makerToken: token }, { takerToken: token }],
+      'assets.tokenAddress': token,
     };
   } else if (_.isString(address)) {
     filter = {

--- a/src/fixtures/tokens/axie.js
+++ b/src/fixtures/tokens/axie.js
@@ -18,4 +18,5 @@ module.exports = {
     '7d': { trades: 5, volume: { token: 5, USD: 21.372 } },
     '1m': { trades: 19, volume: { token: 19, USD: 788.4161750000001 } },
   },
+  type: 1,
 };

--- a/src/fixtures/tokens/brahma.js
+++ b/src/fixtures/tokens/brahma.js
@@ -13,6 +13,7 @@ const BRAHMA_FIXTURE = {
     },
     lastPrice: 0.0049861588509090915,
   },
+  type: 0,
 };
 
 module.exports = BRAHMA_FIXTURE;

--- a/src/fixtures/tokens/weth.js
+++ b/src/fixtures/tokens/weth.js
@@ -27,6 +27,7 @@ const WETH_FIXTURE = {
       volume: { token: 2.87225873367478e22, USD: 4016464.540882649 },
     },
   },
+  type: 0,
 };
 
 module.exports = WETH_FIXTURE;

--- a/src/fixtures/tokens/zrx.js
+++ b/src/fixtures/tokens/zrx.js
@@ -27,6 +27,7 @@ const ZRX_FIXTURE = {
       volume: { token: 1.7224092669903292e23, USD: 50085.864810255036 },
     },
   },
+  type: 0,
 };
 
 module.exports = ZRX_FIXTURE;

--- a/src/model/fill.js
+++ b/src/model/fill.js
@@ -6,53 +6,35 @@ const { FILL_STATUS } = require('../constants');
 const { Schema } = mongoose;
 
 const schema = Schema({
+  assets: [
+    {
+      actor: Number,
+      amount: Number,
+      price: {
+        USD: Number,
+      },
+      tokenAddress: String,
+      tokenId: Number,
+    },
+  ],
   conversions: {
     USD: {
       amount: Number,
       makerFee: Number,
-      makerPrice: Number,
       takerFee: Number,
-      takerPrice: Number,
     },
   },
   date: Date,
   feeRecipient: String,
   maker: String,
-  makerAsset: {
-    assetProxyId: String,
-    tokenAddress: String,
-    tokenId: Number,
-  },
-  makerAmount: Number,
   makerFee: Number,
-  makerToken: String,
   orderHash: String,
-  prices: {
-    maker: Number,
-    taker: Number,
-    saved: { default: false, type: Boolean },
-  },
   protocolVersion: Number,
-  rates: {
-    data: Schema.Types.Mixed,
-    saved: { default: false, type: Boolean },
-  },
   relayerId: Number,
   senderAddress: String,
   status: { default: FILL_STATUS.PENDING, type: Number },
   taker: String,
-  takerAsset: {
-    assetProxyId: String,
-    tokenAddress: String,
-    tokenId: Number,
-  },
-  takerAmount: Number,
   takerFee: Number,
-  takerToken: String,
-  tokenSaved: {
-    maker: Boolean,
-    taker: Boolean,
-  },
   transactionHash: String,
 });
 


### PR DESCRIPTION
# Description

This PR consumes the new assets field on fills. In doing so it decouples the API from the makerToken, takerToken, makerAsset, takerAsset, makerAmount, takerAmount, makerPrice, and takerPrice fields. This provides a big step towards supporting multi-asset fills.