### PR TITLE
Add relayer filter to addresses endpoint

### DIFF
--- a/src/app/routes/v1/addresses.js
+++ b/src/app/routes/v1/addresses.js
@@ -6,6 +6,18 @@ const getAddressesWith24HourStats = require('../../../addresses/get-addresses-wi
 const getAddressesWithStatsForDates = require('../../../addresses/get-addresses-with-stats-for-dates');
 const pagination = require('../../middleware/pagination');
 
+const parseBooleanString = value => {
+  if (value === 'true') {
+    return true;
+  }
+
+  if (value === 'false') {
+    return false;
+  }
+
+  return undefined;
+};
+
 const createRouter = () => {
   const router = new Router();
 
@@ -15,12 +27,19 @@ const createRouter = () => {
     async ({ pagination: { limit, page }, request, response }, next) => {
       const statsPeriod = request.query.statsPeriod || TIME_PERIOD.DAY;
       const { dateFrom, dateTo } = getDatesForTimePeriod(statsPeriod);
+      const excludeRelayers = parseBooleanString(request.query.excludeRelayers);
+
       const { addresses, resultCount } =
         statsPeriod === TIME_PERIOD.DAY
-          ? await getAddressesWith24HourStats({ page, pageSize: limit })
-          : await getAddressesWithStatsForDates(dateFrom, dateTo, {
+          ? await getAddressesWith24HourStats({
+              excludeRelayers,
               page,
-              pageSize: limit,
+              limit,
+            })
+          : await getAddressesWithStatsForDates(dateFrom, dateTo, {
+              excludeRelayers,
+              page,
+              limit,
             });
 
       response.body = {


### PR DESCRIPTION
# Description

This PR excludes relayer addresses from the addresses endpoint by default and introduces a `excludeRelayers` parameter for consumers who wish to include them. 

The addresses endpoint is designed to track high volume makers/takers. Including relayer addresses here by default is unhelpful because they are naturally high volume for popular relayers.