### PR TITLE
Rework relayers endpoint around stats

### DIFF
--- a/src/app/routes/v1/util/transform-relayer.js
+++ b/src/app/routes/v1/util/transform-relayer.js
@@ -1,7 +1,0 @@
-const _ = require('lodash');
-
-const transformRelayer = relayer => {
-  return _.pick(relayer, ['id', 'imageUrl', 'name', 'slug', 'stats', 'url']);
-};
-
-module.exports = transformRelayer;

--- a/src/relayers/get-relayers-with-24-hour-stats.js
+++ b/src/relayers/get-relayers-with-24-hour-stats.js
@@ -1,0 +1,106 @@
+const _ = require('lodash');
+const moment = require('moment');
+
+const RelayerMetric = require('../model/relayer-metric');
+
+const getRelayersWith24HourStats = async options => {
+  const { page, limit } = _.defaults({}, options, {
+    page: 1,
+    limit: 20,
+  });
+
+  const dateTo = moment.utc().toDate();
+  const dateFrom = moment
+    .utc(dateTo)
+    .subtract(24, 'hours')
+    .toDate();
+
+  const result = await RelayerMetric.aggregate([
+    {
+      $match: {
+        date: {
+          $gte: moment
+            .utc(dateFrom)
+            .startOf('day')
+            .toDate(),
+          $lte: dateTo,
+        },
+      },
+    },
+    {
+      $unwind: {
+        path: '$hours',
+      },
+    },
+    {
+      $unwind: {
+        path: '$hours.minutes',
+      },
+    },
+    {
+      $match: {
+        'hours.minutes.date': {
+          $gte: dateFrom,
+          $lte: dateTo,
+        },
+      },
+    },
+    {
+      $group: {
+        _id: '$relayerId',
+        fillCount: {
+          $sum: '$hours.minutes.fillCount',
+        },
+        fillVolume: {
+          $sum: '$hours.minutes.fillVolume',
+        },
+        tradeCount: {
+          $sum: '$hours.minutes.tradeCount',
+        },
+        tradeVolume: {
+          $sum: '$hours.minutes.tradeVolume',
+        },
+      },
+    },
+    {
+      $facet: {
+        relayers: [
+          { $sort: { tradeVolume: -1 } },
+          { $skip: (page - 1) * limit },
+          { $limit: limit },
+          {
+            $lookup: {
+              from: 'relayers',
+              localField: '_id',
+              foreignField: 'lookupId',
+              as: 'relayer',
+            },
+          },
+          {
+            $project: {
+              _id: 0,
+              imageUrl: { $arrayElemAt: ['$relayer.imageUrl', 0] },
+              name: { $arrayElemAt: ['$relayer.name', 0] },
+              slug: { $arrayElemAt: ['$relayer.slug', 0] },
+              stats: {
+                fillCount: '$fillCount',
+                fillVolume: '$fillVolume',
+                tradeCount: '$tradeCount',
+                tradeVolume: '$tradeVolume',
+              },
+              url: { $arrayElemAt: ['$relayer.url', 0] },
+            },
+          },
+        ],
+        resultCount: [{ $count: 'value' }],
+      },
+    },
+  ]);
+
+  return {
+    relayers: _.get(result, '[0].relayers', []),
+    resultCount: _.get(result, '[0].resultCount[0].value', 0),
+  };
+};
+
+module.exports = getRelayersWith24HourStats;

--- a/src/relayers/get-relayers-with-stats-for-dates.js
+++ b/src/relayers/get-relayers-with-stats-for-dates.js
@@ -1,0 +1,78 @@
+const _ = require('lodash');
+
+const RelayerMetric = require('../model/relayer-metric');
+
+const getRelayersWithStatsForDates = async (dateFrom, dateTo, options) => {
+  const { page, limit } = _.defaults({}, options, {
+    page: 1,
+    limit: 20,
+  });
+
+  const result = await RelayerMetric.aggregate([
+    {
+      $match: {
+        date: {
+          $gte: dateFrom,
+          $lte: dateTo,
+        },
+      },
+    },
+    {
+      $group: {
+        _id: '$relayerId',
+        fillCount: {
+          $sum: '$fillCount',
+        },
+        fillVolume: {
+          $sum: '$fillVolume',
+        },
+        tradeCount: {
+          $sum: '$tradeCount',
+        },
+        tradeVolume: {
+          $sum: '$tradeVolume',
+        },
+      },
+    },
+    {
+      $facet: {
+        relayers: [
+          { $sort: { tradeVolume: -1 } },
+          { $skip: (page - 1) * limit },
+          { $limit: limit },
+          {
+            $lookup: {
+              from: 'relayers',
+              localField: '_id',
+              foreignField: 'lookupId',
+              as: 'relayer',
+            },
+          },
+          {
+            $project: {
+              _id: 0,
+              imageUrl: { $arrayElemAt: ['$relayer.imageUrl', 0] },
+              name: { $arrayElemAt: ['$relayer.name', 0] },
+              slug: { $arrayElemAt: ['$relayer.slug', 0] },
+              stats: {
+                fillCount: '$fillCount',
+                fillVolume: '$fillVolume',
+                tradeCount: '$tradeCount',
+                tradeVolume: '$tradeVolume',
+              },
+              url: { $arrayElemAt: ['$relayer.url', 0] },
+            },
+          },
+        ],
+        resultCount: [{ $count: 'value' }],
+      },
+    },
+  ]);
+
+  return {
+    relayers: result[0].relayers,
+    resultCount: result[0].resultCount[0].value,
+  };
+};
+
+module.exports = getRelayersWithStatsForDates;


### PR DESCRIPTION
# Description

This PR reworks the V1 relayers endpoint to use paging and include a `statsPeriod` parameter. This allows consumers to return relayers with stats for 24/7d/1m/1y/all periods.

The V1 relayers endpoint is not currently in use by 0xtracker.com, therefore this rework won't affect any legitimate consumers.