### PR TITLE
Exclude non relayer metrics from relayers

### DIFF
--- a/src/relayers/get-relayers-with-24-hour-stats.js
+++ b/src/relayers/get-relayers-with-24-hour-stats.js
@@ -25,6 +25,7 @@ const getRelayersWith24HourStats = async options => {
             .toDate(),
           $lte: dateTo,
         },
+        relayerId: { $ne: null },
       },
     },
     {

--- a/src/relayers/get-relayers-with-stats-for-dates.js
+++ b/src/relayers/get-relayers-with-stats-for-dates.js
@@ -15,6 +15,7 @@ const getRelayersWithStatsForDates = async (dateFrom, dateTo, options) => {
           $gte: dateFrom,
           $lte: dateTo,
         },
+        relayerId: { $ne: null },
       },
     },
     {


### PR DESCRIPTION
# Description

This PR fixes an issue in the relayers endpoint whereby a null relayer accounting for non-relayer volume is returned.