### PR TITLE
Exclude relayers from trader stats endpoint

### DIFF
--- a/src/relayers/get-relayer-taker-addresses.js
+++ b/src/relayers/get-relayer-taker-addresses.js
@@ -1,0 +1,16 @@
+const _ = require('lodash');
+
+const getRelayers = require('./get-relayers');
+
+const getRelayerTakerAddresses = async () => {
+  const relayers = await getRelayers();
+  const addresses = _(relayers)
+    .map(relayer => relayer.takerAddresses)
+    .flatten()
+    .compact()
+    .value();
+
+  return addresses;
+};
+
+module.exports = getRelayerTakerAddresses;

--- a/src/relayers/get-relayer-taker-addresses.test.js
+++ b/src/relayers/get-relayer-taker-addresses.test.js
@@ -1,0 +1,72 @@
+const getRelayers = require('./get-relayers');
+const getRelayerTakerAddresses = require('./get-relayer-taker-addresses');
+
+jest.mock('./get-relayers');
+
+describe('getRelayerTakerAddresses', () => {
+  it('should return empty array when no relayers have taker addresses', async () => {
+    getRelayers.mockResolvedValue([
+      {
+        _id: '5b489fc19af572783ace3a53',
+        lookupId: 4,
+        name: 'IDT Exchange',
+        feeRecipients: ['0xeb71bad396acaa128aeadbc7dbd59ca32263de01'],
+        id: 'idtExchange',
+        slug: 'idt-exchange',
+      },
+      {
+        _id: '5b48a01d9af572783ace3a56',
+        lookupId: 7,
+        name: 'Radar Relay',
+        feeRecipients: ['0xa258b39954cef5cb142fd567a46cddb31a670124'],
+        id: 'radarRelay',
+        imageUrl: 'https://0xtracker.com/assets/logos/radar-relay.png',
+        slug: 'radar-relay',
+        url: 'https://radarrelay.com',
+      },
+    ]);
+    const takerAddresses = await getRelayerTakerAddresses();
+
+    expect(takerAddresses).toEqual([]);
+  });
+
+  it('should return relayer taker addresses', async () => {
+    getRelayers.mockResolvedValue([
+      {
+        _id: '5b489fc19af572783ace3a53',
+        lookupId: 4,
+        name: 'IDT Exchange',
+        takerAddresses: ['0xeb71bad396acaa128aeadbc7dbd59ca32263de01'],
+        id: 'idtExchange',
+        slug: 'idt-exchange',
+      },
+      {
+        _id: '5b48a01d9af572783ace3a56',
+        lookupId: 7,
+        name: 'Radar Relay',
+        feeRecipients: ['0xa258b39954cef5cb142fd567a46cddb31a670124'],
+        id: 'radarRelay',
+        imageUrl: 'https://0xtracker.com/assets/logos/radar-relay.png',
+        slug: 'radar-relay',
+        url: 'https://radarrelay.com',
+      },
+      {
+        _id: '5c39746f49aa89922fa53bc0',
+        lookupId: 15,
+        id: 'tokenmom',
+        imageUrl: 'https://0xtracker.com/assets/logos/tokenmom.png',
+        name: 'Tokenmom',
+        orderMatcher: true,
+        slug: 'tokenmom',
+        takerAddresses: ['0x4a821aa1affbf7ee89a245bf750d1d7374e77409'],
+        url: 'https://tokenmom.com',
+      },
+    ]);
+    const takerAddresses = await getRelayerTakerAddresses();
+
+    expect(takerAddresses).toEqual([
+      '0xeb71bad396acaa128aeadbc7dbd59ca32263de01',
+      '0x4a821aa1affbf7ee89a245bf750d1d7374e77409',
+    ]);
+  });
+});

--- a/src/stats/compute-24-hour-trader-stats.js
+++ b/src/stats/compute-24-hour-trader-stats.js
@@ -2,6 +2,7 @@ const _ = require('lodash');
 const moment = require('moment');
 
 const AddressMetric = require('../model/address-metric');
+const getRelayerTakerAddresses = require('../relayers/get-relayer-taker-addresses');
 
 const compute24HourTraderStats = async () => {
   const dateTo = moment.utc().toDate();
@@ -9,10 +10,12 @@ const compute24HourTraderStats = async () => {
     .utc(dateTo)
     .subtract(24, 'hours')
     .toDate();
+  const relayerTakerAddresses = await getRelayerTakerAddresses();
 
   const results = await AddressMetric.aggregate([
     {
       $match: {
+        address: { $nin: relayerTakerAddresses },
         date: {
           $gte: moment
             .utc(dateFrom)

--- a/src/stats/compute-trader-stats-for-dates.js
+++ b/src/stats/compute-trader-stats-for-dates.js
@@ -1,11 +1,14 @@
 const _ = require('lodash');
 
 const AddressMetric = require('../model/address-metric');
+const getRelayerTakerAddresses = require('../relayers/get-relayer-taker-addresses');
 
 const computeTraderStatsForDates = async (dateFrom, dateTo) => {
+  const relayerTakerAddresses = await getRelayerTakerAddresses();
   const results = await AddressMetric.aggregate([
     {
       $match: {
+        address: { $nin: relayerTakerAddresses },
         date: {
           $gte: dateFrom,
           $lte: dateTo,

--- a/src/traders/get-traders-with-24-hour-stats.js
+++ b/src/traders/get-traders-with-24-hour-stats.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 const moment = require('moment');
 
 const AddressMetric = require('../model/address-metric');
-const getRelayers = require('../relayers/get-relayers');
+const getRelayerTakerAddresses = require('../relayers/get-relayer-taker-addresses');
 
 const getTradersWith24HourStats = async options => {
   const { excludeRelayers, page, limit, type } = _.defaults({}, options, {
@@ -16,14 +16,7 @@ const getTradersWith24HourStats = async options => {
     .utc(dateTo)
     .subtract(24, 'hours')
     .toDate();
-
-  const relayers = await getRelayers();
-
-  const relayerTakerAddresses = _(relayers)
-    .map(relayer => relayer.takerAddresses)
-    .flatten()
-    .compact()
-    .value();
+  const relayerTakerAddresses = await getRelayerTakerAddresses();
 
   const result = await AddressMetric.aggregate(
     _.compact([

--- a/src/traders/get-traders-with-stats-for-dates.js
+++ b/src/traders/get-traders-with-stats-for-dates.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 
 const AddressMetric = require('../model/address-metric');
-const getRelayers = require('../relayers/get-relayers');
+const getRelayerTakerAddresses = require('../relayers/get-relayer-taker-addresses');
 
 const getTradersWithStatsForDates = async (dateFrom, dateTo, options) => {
   const { excludeRelayers, page, limit, type } = _.defaults({}, options, {
@@ -10,14 +10,7 @@ const getTradersWithStatsForDates = async (dateFrom, dateTo, options) => {
     limit: 20,
   });
 
-  const relayers = await getRelayers();
-
-  const relayerTakerAddresses = _(relayers)
-    .map(relayer => relayer.takerAddresses)
-    .flatten()
-    .compact()
-    .value();
-
+  const relayerTakerAddresses = await getRelayerTakerAddresses();
   const result = await AddressMetric.aggregate(
     _.compact([
       {


### PR DESCRIPTION
# Description

This PR updates the trader stats endpoint to ensure it doesn't include relayer addresses in its count.