### PR TITLE
Add status and date filters to the fills endpoint

### DIFF
--- a/src/app/routes/v1/fills.js
+++ b/src/app/routes/v1/fills.js
@@ -14,6 +14,14 @@ const searchFills = require('../../../fills/search-fills');
 const transformFill = require('./util/transform-fill');
 const transformFills = require('./util/transform-fills');
 
+const parseDate = dateString => {
+  if (dateString === undefined) {
+    return undefined;
+  }
+
+  return moment(dateString);
+};
+
 const createRouter = () => {
   const router = new Router({ prefix: '/fills' });
 
@@ -25,10 +33,14 @@ const createRouter = () => {
       const relayerId = request.query.relayer;
       const query = request.query.q;
       const relayerLookupId = await getRelayerLookupId(relayerId);
+      const dateFrom = parseDate(request.query.dateFrom);
+      const dateTo = parseDate(request.query.dateTo);
       const protocolVersion =
         request.query.protocolVersion !== undefined
           ? _.toNumber(request.query.protocolVersion)
           : undefined;
+
+      const minDate = moment().subtract(6, 'months');
 
       if (
         status !== undefined &&
@@ -61,10 +73,44 @@ const createRouter = () => {
         );
       }
 
+      if (dateFrom !== undefined && !dateFrom.isValid()) {
+        throw new InvalidParameterError(
+          'Must be in ISO 8601 format',
+          'Invalid query parameter: dateFrom',
+        );
+      } else if (dateFrom !== undefined && dateFrom < minDate) {
+        throw new InvalidParameterError(
+          'Cannot be more than six months ago',
+          'Invalid query parameter: dateFrom',
+        );
+      } else if (
+        dateFrom !== undefined &&
+        dateTo !== undefined &&
+        dateFrom > dateTo
+      ) {
+        throw new InvalidParameterError(
+          'Cannot be greater than dateTo',
+          'Invalid query parameter: dateTo',
+        );
+      }
+
+      if (dateTo !== undefined && !dateTo.isValid()) {
+        throw new InvalidParameterError(
+          'Must be in ISO 8601 format',
+          'Invalid query parameter: dateTo',
+        );
+      } else if (dateTo !== undefined && dateTo < minDate) {
+        throw new InvalidParameterError(
+          'Cannot be more than six months ago',
+          'Invalid query parameter: dateTo',
+        );
+      }
+
       const { docs, pages, total } = await searchFills(
         {
           address,
-          dateFrom: moment().subtract(6, 'months'),
+          dateFrom: dateFrom !== undefined ? dateFrom : minDate,
+          dateTo,
           protocolVersion,
           query,
           relayerId: relayerLookupId,

--- a/src/fills/reverse-map-status.js
+++ b/src/fills/reverse-map-status.js
@@ -1,0 +1,19 @@
+const _ = require('lodash');
+const { FILL_STATUS } = require('../constants');
+
+const reverseMapStatus = statusLabel => {
+  if (statusLabel === undefined) {
+    return undefined;
+  }
+
+  const upperLabel = _.toUpper(statusLabel);
+  const status = FILL_STATUS[upperLabel];
+
+  if (status === undefined) {
+    throw new Error(`Unrecognised status label: ${statusLabel}`);
+  }
+
+  return status;
+};
+
+module.exports = reverseMapStatus;

--- a/src/fills/reverse-map-status.test.js
+++ b/src/fills/reverse-map-status.test.js
@@ -1,0 +1,33 @@
+const reverseMapStatus = require('./reverse-map-status');
+
+describe('reverseMapStatus', () => {
+  it('should return undefined when label is undefined', () => {
+    const status = reverseMapStatus(undefined);
+
+    expect(status).toBeUndefined();
+  });
+
+  it('should throw an error when label is unrecognised', () => {
+    expect(() => {
+      reverseMapStatus('fubar');
+    }).toThrow(new Error('Unrecognised status label: fubar'));
+  });
+
+  it('should map "failed" to 2', () => {
+    const status = reverseMapStatus('failed');
+
+    expect(status).toBe(2);
+  });
+
+  it('should map "pending" to 0', () => {
+    const status = reverseMapStatus('pending');
+
+    expect(status).toBe(0);
+  });
+
+  it('should map "successful" to 1', () => {
+    const status = reverseMapStatus('successful');
+
+    expect(status).toBe(1);
+  });
+});

--- a/src/fills/search-fills.js
+++ b/src/fills/search-fills.js
@@ -9,6 +9,7 @@ const buildQuery = ({
   protocolVersion,
   query,
   relayerId,
+  status,
   token,
 }) => {
   const filters = [];
@@ -54,6 +55,10 @@ const buildQuery = ({
         type: 'phrase',
       },
     });
+  }
+
+  if (_.isNumber(status)) {
+    filters.push({ term: { status } });
   }
 
   return filters.length === 0

--- a/src/fills/search-fills.js
+++ b/src/fills/search-fills.js
@@ -6,6 +6,7 @@ const Fill = require('../model/fill');
 const buildQuery = ({
   address,
   dateFrom,
+  dateTo,
   protocolVersion,
   query,
   relayerId,
@@ -14,8 +15,15 @@ const buildQuery = ({
 }) => {
   const filters = [];
 
-  if (dateFrom !== undefined) {
-    filters.push({ range: { date: { gte: dateFrom.toISOString() } } });
+  if (dateFrom !== undefined || dateTo !== undefined) {
+    filters.push({
+      range: {
+        date: {
+          gte: dateFrom !== undefined ? dateFrom.toISOString() : undefined,
+          lte: dateTo !== undefined ? dateTo.toISOString() : undefined,
+        },
+      },
+    });
   }
 
   if (_.isFinite(relayerId)) {


### PR DESCRIPTION
This PR adds three new filters to the fills endpoint:

* status - filtering of fills by successful, failed, and pending
* dateFrom - filtering of fills after a particular date
* dateTo - filtering of fills until a particular date