### PR TITLE
Add value parameters to fills endpoint

### DIFF
--- a/src/app/routes/v1/fills.js
+++ b/src/app/routes/v1/fills.js
@@ -22,6 +22,14 @@ const parseDate = dateString => {
   return moment(dateString);
 };
 
+const parseNumber = numberString => {
+  if (numberString === undefined) {
+    return undefined;
+  }
+
+  return _.toNumber(numberString);
+};
+
 const createRouter = () => {
   const router = new Router({ prefix: '/fills' });
 
@@ -35,6 +43,8 @@ const createRouter = () => {
       const relayerLookupId = await getRelayerLookupId(relayerId);
       const dateFrom = parseDate(request.query.dateFrom);
       const dateTo = parseDate(request.query.dateTo);
+      const valueFrom = parseNumber(request.query.valueFrom);
+      const valueTo = parseNumber(request.query.valueTo);
       const protocolVersion =
         request.query.protocolVersion !== undefined
           ? _.toNumber(request.query.protocolVersion)
@@ -116,6 +126,8 @@ const createRouter = () => {
           relayerId: relayerLookupId,
           status: reverseMapStatus(status),
           token,
+          valueFrom,
+          valueTo,
         },
         { limit, page },
       );

--- a/src/app/routes/v1/fills.js
+++ b/src/app/routes/v1/fills.js
@@ -100,7 +100,7 @@ const createRouter = () => {
       ) {
         throw new InvalidParameterError(
           'Cannot be greater than dateTo',
-          'Invalid query parameter: dateTo',
+          'Invalid query parameter: dateFrom',
         );
       }
 
@@ -113,6 +113,29 @@ const createRouter = () => {
         throw new InvalidParameterError(
           'Cannot be more than six months ago',
           'Invalid query parameter: dateTo',
+        );
+      }
+
+      if (valueFrom !== undefined && valueFrom < 0) {
+        throw new InvalidParameterError(
+          'Cannot be less than zero',
+          'Invalid query parameter: valueFrom',
+        );
+      } else if (
+        valueFrom !== undefined &&
+        valueTo !== undefined &&
+        valueFrom > valueTo
+      ) {
+        throw new InvalidParameterError(
+          'Cannot be greater than valueTo',
+          'Invalid query parameter: valueFrom',
+        );
+      }
+
+      if (valueTo !== undefined && valueTo < 0) {
+        throw new InvalidParameterError(
+          'Cannot be less than zero',
+          'Invalid query parameter: valueTo',
         );
       }
 

--- a/src/fills/search-fills.js
+++ b/src/fills/search-fills.js
@@ -12,6 +12,8 @@ const buildQuery = ({
   relayerId,
   status,
   token,
+  valueFrom,
+  valueTo,
 }) => {
   const filters = [];
 
@@ -21,6 +23,17 @@ const buildQuery = ({
         date: {
           gte: dateFrom !== undefined ? dateFrom.toISOString() : undefined,
           lte: dateTo !== undefined ? dateTo.toISOString() : undefined,
+        },
+      },
+    });
+  }
+
+  if (valueFrom !== undefined || valueTo !== undefined) {
+    filters.push({
+      range: {
+        value: {
+          gte: valueFrom !== undefined ? valueFrom : undefined,
+          lte: valueTo !== undefined ? valueFrom : undefined,
         },
       },
     });


### PR DESCRIPTION
This PR adds `valueFrom` and `valueTo` parameters to the fills endpoint which allow consumers to search for fills by their USD value.