### PR TITLE
Add support for unknown relayers

### DIFF
--- a/src/fills/search-fills.js
+++ b/src/fills/search-fills.js
@@ -46,6 +46,14 @@ const buildQuery = ({
     filters.push({ term: { relayerId } });
   }
 
+  if (_.isNull(relayerId)) {
+    exclusions.push({
+      exists: {
+        field: 'relayerId',
+      },
+    });
+  }
+
   if (_.isFinite(protocolVersion)) {
     filters.push({ term: { protocolVersion } });
   }

--- a/src/metrics/get-network-metrics.js
+++ b/src/metrics/get-network-metrics.js
@@ -37,7 +37,8 @@ const getNetworkMetrics = async (
       $match: _.merge(
         { date: { $gte: dayFrom, $lte: dayTo } },
         ..._.compact([
-          _.isNumber(filter.relayerId) && { relayerId: filter.relayerId },
+          _.isNumber(filter.relayerId) ||
+            (_.isNull(filter.relayerId) && { relayerId: filter.relayerId }),
         ]),
       ),
     },

--- a/src/relayers/get-relayer-by-slug.js
+++ b/src/relayers/get-relayer-by-slug.js
@@ -1,6 +1,14 @@
 const Relayer = require('../model/relayer');
 
 const getRelayerBySlug = async slug => {
+  if (slug === 'unknown') {
+    return {
+      id: 'unknown',
+      name: 'Unknown',
+      slug: 'unknown',
+    };
+  }
+
   const relayer = await Relayer.findOne({ slug }).lean();
 
   return relayer;

--- a/src/relayers/get-relayer-lookup-id.js
+++ b/src/relayers/get-relayer-lookup-id.js
@@ -7,6 +7,10 @@ const getRelayerLookupId = async relayerId => {
     return undefined;
   }
 
+  if (relayerId === 'unknown') {
+    return null;
+  }
+
   const relayers = await getRelayers();
   const relayer = relayers[relayerId];
 

--- a/src/relayers/get-relayers-with-24-hour-stats.js
+++ b/src/relayers/get-relayers-with-24-hour-stats.js
@@ -25,7 +25,6 @@ const getRelayersWith24HourStats = async options => {
             .toDate(),
           $lte: dateTo,
         },
-        relayerId: { $ne: null },
       },
     },
     {
@@ -108,7 +107,11 @@ const getRelayersWith24HourStats = async options => {
   ]);
 
   return {
-    relayers: _.get(result, '[0].relayers', []),
+    relayers: _.get(result, '[0].relayers', []).map(relayer =>
+      relayer.id === undefined
+        ? { ...relayer, id: 'unknown', name: 'Unknown', slug: 'unknown' }
+        : relayer,
+    ),
     resultCount: _.get(result, '[0].totals[0].relayerCount', 0),
   };
 };

--- a/src/relayers/get-relayers-with-stats-for-dates.js
+++ b/src/relayers/get-relayers-with-stats-for-dates.js
@@ -15,7 +15,6 @@ const getRelayersWithStatsForDates = async (dateFrom, dateTo, options) => {
           $gte: dateFrom,
           $lte: dateTo,
         },
-        relayerId: { $ne: null },
       },
     },
     {
@@ -79,7 +78,11 @@ const getRelayersWithStatsForDates = async (dateFrom, dateTo, options) => {
   ]);
 
   return {
-    relayers: _.get(result, '[0].relayers', []),
+    relayers: _.get(result, '[0].relayers', []).map(relayer =>
+      relayer.id === undefined
+        ? { ...relayer, id: 'unknown', name: 'Unknown', slug: 'unknown' }
+        : relayer,
+    ),
     resultCount: _.get(result, '[0].totals[0].relayerCount', 0),
   };
 };


### PR DESCRIPTION
This PR implements support for unknown relayers by making the following changes:

* Expose an unknown relayer entity via the relayers endpoint
* Expose unknown relayer metrics
* Allow filtering of fills by unknown relayer
* Allow fetching of the individual unknown relayer entity