### PR TITLE
Add supply and market cap stats to tokens

### DIFF
--- a/src/app/routes/v1/util/transform-token.js
+++ b/src/app/routes/v1/util/transform-token.js
@@ -4,45 +4,76 @@ const { TOKEN_TYPE } = require('../../../../constants');
 const formatTokenType = require('../../../../tokens/format-token-type');
 const getCdnTokenImageUrl = require('../../../../tokens/get-cdn-token-image-url');
 
-const transformToken = (token, price, stats, statsPeriod) => {
+const getOptionalTokenValue = (token, key) =>
+  _.isNil(token[key]) ? null : token[key];
+
+const calculateMarketCap = (circulatingSupply, totalSupply, currentPrice) => {
+  const supply = circulatingSupply !== null ? circulatingSupply : totalSupply;
+
+  if (currentPrice === null || supply === null) {
+    return null;
+  }
+
+  return supply * currentPrice;
+};
+
+const transformToken = (token, tokenPrice, stats, statsPeriod) => {
+  const circulatingSupply = getOptionalTokenValue(token, 'circulatingSupply');
+  const name = getOptionalTokenValue(token, 'name');
+  const symbol = getOptionalTokenValue(token, 'symbol');
+  const totalSupply = getOptionalTokenValue(token, 'totalSupply');
+  const type = formatTokenType(token.type);
+
+  const price =
+    token.type === TOKEN_TYPE.ERC20
+      ? {
+          change: _.get(tokenPrice, 'priceChange', null),
+          close: _.get(tokenPrice, 'priceUSD', null),
+          high: _.get(tokenPrice, 'maxPriceUSD', null),
+          last: _.get(tokenPrice, 'priceUSD', null),
+          low: _.get(tokenPrice, 'minPriceUSD', null),
+          open: _.get(tokenPrice, 'openPriceUSD', null),
+        }
+      : {
+          change: null,
+          close: null,
+          high: null,
+          last: null,
+          low: null,
+          open: null,
+        };
+
+  const imageUrl = _.isString(token.imageUrl)
+    ? getCdnTokenImageUrl(token.imageUrl)
+    : null;
+
+  const lastTrade =
+    _.get(tokenPrice, 'fillId', null) !== null
+      ? {
+          date: tokenPrice.date,
+          id: tokenPrice.fillId,
+        }
+      : null;
+
+  const marketCap = calculateMarketCap(
+    circulatingSupply,
+    totalSupply,
+    price.close,
+  );
+
   return {
     address: token.address,
-    imageUrl: _.isString(token.imageUrl)
-      ? getCdnTokenImageUrl(token.imageUrl)
-      : undefined,
-    lastTrade: _.isObject(price)
-      ? {
-          date: price.date,
-          id: price.fillId,
-        }
-      : null,
-    name: token.name,
-    price: {
-      change:
-        token.type === TOKEN_TYPE.ERC20
-          ? _.get(price, 'priceChange', null)
-          : null,
-      close:
-        token.type === TOKEN_TYPE.ERC20 ? _.get(price, 'priceUSD', null) : null,
-      high:
-        token.type === TOKEN_TYPE.ERC20
-          ? _.get(price, 'maxPriceUSD', null)
-          : null,
-      last:
-        token.type === TOKEN_TYPE.ERC20 ? _.get(price, 'priceUSD', null) : null,
-      low:
-        token.type === TOKEN_TYPE.ERC20
-          ? _.get(price, 'minPriceUSD', null)
-          : null,
-      open:
-        token.type === TOKEN_TYPE.ERC20
-          ? _.get(price, 'openPriceUSD', null)
-          : null,
-    },
+    circulatingSupply,
+    imageUrl,
+    lastTrade,
+    marketCap,
+    name,
+    price,
     stats,
     statsPeriod,
-    symbol: token.symbol,
-    type: formatTokenType(token.type),
+    symbol,
+    totalSupply,
+    type,
   };
 };
 

--- a/src/app/routes/v1/util/transform-token.test.js
+++ b/src/app/routes/v1/util/transform-token.test.js
@@ -33,8 +33,10 @@ it('should only return white-listed fields', () => {
 
   expect(transformed).toEqual({
     address: '0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359',
+    circulatingSupply: null,
     imageUrl: 'http://tmpuri.org/test.jpg',
     lastTrade: null,
+    marketCap: null,
     name: 'DAI Stablecoin',
     price: {
       change: null,
@@ -45,6 +47,7 @@ it('should only return white-listed fields', () => {
       open: null,
     },
     symbol: 'DAI',
+    totalSupply: null,
   });
 });
 
@@ -58,7 +61,10 @@ it('should transform tokens which dont have an image url', () => {
 
   expect(transformed).toEqual({
     address: '0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359',
+    circulatingSupply: null,
+    imageUrl: null,
     lastTrade: null,
+    marketCap: null,
     name: 'DAI Stablecoin',
     price: {
       change: null,
@@ -69,5 +75,6 @@ it('should transform tokens which dont have an image url', () => {
       open: null,
     },
     symbol: 'DAI',
+    totalSupply: null,
   });
 });

--- a/src/model/token.js
+++ b/src/model/token.js
@@ -14,6 +14,7 @@ const tokenStatsShape = {
 
 const schema = Schema({
   address: String,
+  circulatingSupply: Number,
   decimals: Number,
   imageUrl: { type: String, trim: true },
   name: String,
@@ -30,6 +31,7 @@ const schema = Schema({
     '24h': tokenStatsShape,
   },
   symbol: String,
+  totalSupply: Number,
   type: Number,
 });
 


### PR DESCRIPTION
This PR adds three new fields to token endpoints:

* currentSupply
* totalSupply
* marketCap