### PR TITLE
Create lookup endpoints for tokens & relayers

### DIFF
--- a/src/app/routes/v1/index.js
+++ b/src/app/routes/v1/index.js
@@ -6,9 +6,11 @@ const createAssetBridgesRouter = require('./asset-bridges');
 const createFillsRouter = require('./fills');
 const createMetricsRouter = require('./metrics');
 const createProtocolsRouter = require('./protocols');
+const createRelayerLookupRouter = require('./relayer-lookup');
 const createRelayerRouter = require('./relayer');
 const createRelayersRouter = require('./relayers');
 const createStatsRouter = require('./stats');
+const createTokenLookupRouter = require('./token-lookup');
 const createTokenRouter = require('./token');
 const createTokensRouter = require('./tokens');
 const createTradersRouter = require('./traders');
@@ -23,9 +25,11 @@ const createRouter = () => {
     createFillsRouter().routes(),
     createMetricsRouter().routes(),
     createProtocolsRouter().routes(),
+    createRelayerLookupRouter().routes(),
     createRelayerRouter().routes(),
     createRelayersRouter().routes(),
     createStatsRouter().routes(),
+    createTokenLookupRouter().routes(),
     createTokenRouter().routes(),
     createTokensRouter().routes(),
     createTradersRouter().routes(),

--- a/src/app/routes/v1/relayer-lookup.js
+++ b/src/app/routes/v1/relayer-lookup.js
@@ -1,0 +1,28 @@
+const _ = require('lodash');
+const Router = require('koa-router');
+
+const searchRelayers = require('../../../relayers/search-relayers');
+
+const createRouter = () => {
+  const router = new Router();
+
+  router.get('/relayer-lookup', async ({ request, response }, next) => {
+    const { q } = request.query;
+
+    const limit =
+      request.query.limit !== undefined ? _.toNumber(request.query.limit) : 5;
+    const relayers = await searchRelayers(q, { limit });
+
+    response.body = {
+      limit,
+      relayers: relayers.map(relayer => relayer),
+      q,
+    };
+
+    await next();
+  });
+
+  return router;
+};
+
+module.exports = createRouter;

--- a/src/app/routes/v1/token-lookup.js
+++ b/src/app/routes/v1/token-lookup.js
@@ -1,0 +1,40 @@
+const _ = require('lodash');
+const Router = require('koa-router');
+
+const formatTokenType = require('../../../tokens/format-token-type');
+const getCdnTokenImageUrl = require('../../../tokens/get-cdn-token-image-url');
+const searchTokens = require('../../../tokens/search-tokens');
+
+const createRouter = () => {
+  const router = new Router();
+
+  router.get('/token-lookup', async ({ request, response }, next) => {
+    const { q } = request.query;
+
+    const limit =
+      request.query.limit !== undefined ? _.toNumber(request.query.limit) : 5;
+    const tokens = await searchTokens(q, { limit });
+
+    response.body = {
+      limit,
+      tokens: tokens.map(token => ({
+        address: token.address,
+        circulatingSupply: _.get(token, 'circulatingSupply', null),
+        imageUrl: _.isString(token.imageUrl)
+          ? getCdnTokenImageUrl(token.imageUrl)
+          : null,
+        name: _.get(token, 'name', null),
+        symbol: _.get(token, 'symbol', null),
+        totalSupply: _.get(token, 'totalSupply', null),
+        type: formatTokenType(token.type),
+      })),
+      q,
+    };
+
+    await next();
+  });
+
+  return router;
+};
+
+module.exports = createRouter;

--- a/src/relayers/search-relayers.js
+++ b/src/relayers/search-relayers.js
@@ -1,0 +1,14 @@
+const Relayer = require('../model/relayer');
+
+const searchRelayers = async (query, options) => {
+  const relayers = await Relayer.find(
+    query.length > 0 ? { name: new RegExp(query, 'ig') } : {},
+  )
+    .sort({ name: 1 })
+    .limit(options.limit)
+    .lean();
+
+  return relayers;
+};
+
+module.exports = searchRelayers;

--- a/src/tokens/search-tokens.js
+++ b/src/tokens/search-tokens.js
@@ -1,0 +1,22 @@
+const Token = require('../model/token');
+
+const searchTokens = async (query, options) => {
+  const tokens = await Token.find(
+    query.length > 0
+      ? {
+          $or: [
+            { address: query },
+            { name: new RegExp(query, 'ig') },
+            { symbol: new RegExp(query, 'ig') },
+          ],
+        }
+      : {},
+  )
+    .sort({ name: 1 })
+    .limit(options.limit)
+    .lean();
+
+  return tokens;
+};
+
+module.exports = searchTokens;


### PR DESCRIPTION
This PR introduces two new endpoints for search relayers and tokens. The search logic uses a simple regex for the time-being but can be updated to use Elasticsearch in the future which would allow for a more intelligent fuzzy search with result scores for sorting.