### PR TITLE
Add stats to relayer endpoint and relayer tokens

### DIFF
--- a/src/app/middleware/relayer.js
+++ b/src/app/middleware/relayer.js
@@ -15,7 +15,7 @@ const normalizeStringParam = param => {
   return param;
 };
 
-const createMiddleware = (paramName, defaultValue) => async (context, next) => {
+const createMiddleware = paramName => async (context, next) => {
   const { request } = context;
 
   const relayerId = normalizeStringParam(request.query[paramName]);
@@ -34,7 +34,6 @@ const createMiddleware = (paramName, defaultValue) => async (context, next) => {
     return;
   }
 
-  _.set(context, ['params', paramName], defaultValue);
   await next();
 };
 

--- a/src/app/routes/v1/relayer.js
+++ b/src/app/routes/v1/relayer.js
@@ -1,28 +1,90 @@
 const _ = require('lodash');
 const Router = require('koa-router');
 
+const { TIME_PERIOD } = require('../../../constants');
 const getRelayerBySlug = require('../../../relayers/get-relayer-by-slug');
+const getRelayerStatsForPeriod = require('../../../relayers/get-relayer-stats-for-period');
+const getTokensForRelayerInPeriod = require('../../../tokens/get-tokens-for-relayer-in-period');
+const middleware = require('../../middleware');
 const transformRelayer = require('./util/transform-relayer');
 
 const createRouter = () => {
   const router = new Router({ prefix: '/relayers/:slug' });
 
-  router.get('/', async ({ params, response }, next) => {
-    const { slug } = params;
-    const relayer = await getRelayerBySlug(slug);
+  router.get(
+    '/',
+    middleware.timePeriod('statsPeriod', TIME_PERIOD.DAY),
+    async ({ params, response }, next) => {
+      const { slug, statsPeriod } = params;
+      const relayer = await getRelayerBySlug(slug);
 
-    if (_.isNull(relayer)) {
-      response.status = 404;
+      if (_.isNull(relayer)) {
+        response.status = 404;
+        await next();
+        return;
+      }
+
+      const stats = await getRelayerStatsForPeriod(
+        relayer.lookupId,
+        statsPeriod,
+      );
+
+      const viewModel = transformRelayer(relayer, stats);
+
+      response.body = viewModel;
+
       await next();
-      return;
-    }
+    },
+  );
 
-    const viewModel = transformRelayer(relayer);
+  router.get(
+    '/tokens',
+    middleware.timePeriod('statsPeriod', TIME_PERIOD.DAY),
+    middleware.enum(
+      'sortBy',
+      ['fillCount', 'fillVolumeUSD', 'tradeCount', 'tradeVolumeUSD'],
+      'tradeVolumeUSD',
+    ),
+    middleware.pagination({
+      defaultLimit: 20,
+      maxLimit: 50,
+      maxPage: Infinity,
+    }),
+    async ({ pagination, params, response }, next) => {
+      const { slug, sortBy, statsPeriod } = params;
+      const { limit, page } = pagination;
 
-    response.body = viewModel;
+      const relayer = await getRelayerBySlug(slug);
 
-    await next();
-  });
+      if (_.isNull(relayer)) {
+        response.status = 404;
+        await next();
+        return;
+      }
+
+      const { tokens, resultCount } = await getTokensForRelayerInPeriod(
+        relayer.lookupId,
+        statsPeriod,
+        {
+          sortBy,
+          limit,
+          page,
+        },
+      );
+
+      response.body = {
+        limit,
+        page,
+        pageCount: Math.ceil(resultCount / limit),
+        tokens,
+        sortBy,
+        statsPeriod,
+        total: resultCount,
+      };
+
+      await next();
+    },
+  );
 
   return router;
 };

--- a/src/app/routes/v1/util/__snapshots__/transform-relayer.test.js.snap
+++ b/src/app/routes/v1/util/__snapshots__/transform-relayer.test.js.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`transformRelayer should transfer relayer with stats 1`] = `
+Object {
+  "id": "starBit",
+  "imageUrl": "https://resources.0xtracker.com/logos/starbit.png",
+  "name": "STAR BIT",
+  "slug": "star-bit",
+  "stats": Object {
+    "fillCount": 687,
+    "fillVolume": 18907,
+    "tradeCount": 512,
+    "tradeVolume": 150567.87,
+  },
+  "url": "https://www.starbitex.com",
+}
+`;
+
+exports[`transformRelayer should transform relayer with minimal fields 1`] = `
+Object {
+  "id": "starBit",
+  "imageUrl": null,
+  "name": "STAR BIT",
+  "slug": "star-bit",
+  "stats": Object {
+    "fillCount": 687,
+    "fillVolume": 18907,
+    "tradeCount": 512,
+    "tradeVolume": 150567.87,
+  },
+  "url": null,
+}
+`;
+
+exports[`transformRelayer should transform relayer without stats 1`] = `
+Object {
+  "id": "starBit",
+  "imageUrl": "https://resources.0xtracker.com/logos/starbit.png",
+  "name": "STAR BIT",
+  "slug": "star-bit",
+  "url": "https://www.starbitex.com",
+}
+`;

--- a/src/app/routes/v1/util/transform-relayer.js
+++ b/src/app/routes/v1/util/transform-relayer.js
@@ -1,7 +1,12 @@
-const _ = require('lodash');
-
-const transformRelayer = relayer => {
-  return _.pick(relayer, ['id', 'imageUrl', 'name', 'slug', 'url']);
+const transformRelayer = (relayer, stats) => {
+  return {
+    id: relayer.id,
+    imageUrl: relayer.imageUrl,
+    name: relayer.name,
+    slug: relayer.slug,
+    stats,
+    url: relayer.url,
+  };
 };
 
 module.exports = transformRelayer;

--- a/src/app/routes/v1/util/transform-relayer.js
+++ b/src/app/routes/v1/util/transform-relayer.js
@@ -1,12 +1,17 @@
+const _ = require('lodash');
+
 const transformRelayer = (relayer, stats) => {
-  return {
-    id: relayer.id,
-    imageUrl: relayer.imageUrl,
-    name: relayer.name,
-    slug: relayer.slug,
-    stats,
-    url: relayer.url,
-  };
+  return _.pickBy(
+    {
+      id: relayer.id,
+      imageUrl: _.get(relayer, 'imageUrl', null),
+      name: relayer.name,
+      slug: relayer.slug,
+      stats,
+      url: _.get(relayer, 'url', null),
+    },
+    val => val !== undefined,
+  );
 };
 
 module.exports = transformRelayer;

--- a/src/app/routes/v1/util/transform-relayer.test.js
+++ b/src/app/routes/v1/util/transform-relayer.test.js
@@ -1,0 +1,32 @@
+const starBit = require('../../../../fixtures/relayers/star-bit');
+const transformRelayer = require('./transform-relayer');
+
+const stats = {
+  tradeVolume: 150567.87,
+  tradeCount: 512,
+  fillVolume: 18907,
+  fillCount: 687,
+};
+
+describe('transformRelayer', () => {
+  it('should transfer relayer with stats', () => {
+    const transformed = transformRelayer(starBit, stats);
+
+    expect(transformed).toMatchSnapshot();
+  });
+
+  it('should transform relayer without stats', () => {
+    const transformed = transformRelayer(starBit);
+
+    expect(transformed).toMatchSnapshot();
+  });
+
+  it('should transform relayer with minimal fields', () => {
+    const transformed = transformRelayer(
+      { ...starBit, imageUrl: undefined, url: undefined },
+      stats,
+    );
+
+    expect(transformed).toMatchSnapshot();
+  });
+});

--- a/src/fixtures/relayers/star-bit.js
+++ b/src/fixtures/relayers/star-bit.js
@@ -1,0 +1,17 @@
+const mongoose = require('mongoose');
+
+module.exports = {
+  _id: mongoose.Types.ObjectId('5b48a0399af572783ace3a58'),
+  lookupId: 9,
+  name: 'STAR BIT',
+  feeRecipients: [
+    '0x8124071f810d533ff63de61d0c98db99eeb99d64',
+    '0xc370d2a5920344aa6b7d8d11250e3e861434cbdd',
+  ],
+  id: 'starBit',
+  imageUrl: 'https://resources.0xtracker.com/logos/starbit.png',
+  orderMatcher: true,
+  slug: 'star-bit',
+  url: 'https://www.starbitex.com',
+  takerAddresses: ['0x0681e844593a051e2882ec897ecd5444efe19ff2'],
+};

--- a/src/relayers/get-relayer-by-slug.js
+++ b/src/relayers/get-relayer-by-slug.js
@@ -4,6 +4,7 @@ const getRelayerBySlug = async slug => {
   if (slug === 'unknown') {
     return {
       id: 'unknown',
+      lookupId: null,
       name: 'Unknown',
       slug: 'unknown',
     };

--- a/src/relayers/get-relayer-stats-for-period.js
+++ b/src/relayers/get-relayer-stats-for-period.js
@@ -1,0 +1,62 @@
+const elasticsearch = require('../util/elasticsearch');
+const getDatesForTimePeriod = require('../util/get-dates-for-time-period');
+
+const getRelayerStatsForPeriod = async (relayerId, period) => {
+  const { dateFrom, dateTo } = getDatesForTimePeriod(period);
+  const res = await elasticsearch.getClient().search({
+    index: 'fills',
+    body: {
+      aggs: {
+        fillCount: {
+          value_count: { field: '_id' },
+        },
+        fillVolume: {
+          sum: { field: 'value' },
+        },
+        tradeCount: {
+          sum: { field: 'tradeCountContribution' },
+        },
+        traderCount: {
+          cardinality: { field: 'traders' },
+        },
+        tradeVolume: {
+          sum: { field: 'tradeVolume' },
+        },
+      },
+      size: 0,
+      query: {
+        bool: {
+          filter: [
+            { term: { relayerId } },
+            {
+              range: {
+                date: {
+                  gte: dateFrom,
+                  lte: dateTo,
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+  });
+
+  const {
+    fillCount,
+    fillVolume,
+    tradeCount,
+    traderCount,
+    tradeVolume,
+  } = res.body.aggregations;
+
+  return {
+    fillCount: fillCount.value,
+    fillVolume: fillVolume.value,
+    tradeCount: tradeCount.value,
+    traderCount: traderCount.value,
+    tradeVolume: tradeVolume.value,
+  };
+};
+
+module.exports = getRelayerStatsForPeriod;

--- a/src/tokens/get-tokens-for-relayer-in-period.js
+++ b/src/tokens/get-tokens-for-relayer-in-period.js
@@ -1,0 +1,130 @@
+const _ = require('lodash');
+
+const elasticsearch = require('../util/elasticsearch');
+const getCdnTokenImageUrl = require('./get-cdn-token-image-url');
+const getDatesForPeriod = require('../util/get-dates-for-time-period');
+const Token = require('../model/token');
+
+const getElasticsearchOrderByKey = sortBy => {
+  if (sortBy === 'fillCount') {
+    return '_count';
+  }
+
+  return sortBy;
+};
+
+const getRelayersForTokenInPeriod = async (relayerId, period, options) => {
+  const { limit, page, sortBy } = options;
+  const { dateFrom, dateTo } = getDatesForPeriod(period);
+
+  const startIndex = (page - 1) * limit;
+
+  const response = await elasticsearch.getClient().search({
+    index: 'traded_tokens',
+    body: {
+      query: {
+        bool: {
+          filter: [
+            {
+              range: {
+                date: {
+                  gte: dateFrom,
+                  lte: dateTo,
+                },
+              },
+            },
+            {
+              term: {
+                relayerId,
+              },
+            },
+          ],
+        },
+      },
+      aggs: {
+        stats_by_token: {
+          terms: {
+            field: 'tokenAddress',
+            missing: -1,
+            size: limit * page,
+            order: { [getElasticsearchOrderByKey(sortBy)]: 'desc' },
+          },
+          aggs: {
+            fillVolume: {
+              sum: {
+                field: 'filledAmount',
+              },
+            },
+            fillVolumeUSD: {
+              sum: {
+                field: 'filledAmountUSD',
+              },
+            },
+            tradeCount: {
+              sum: {
+                field: 'tradeCountContribution',
+              },
+            },
+            tradeVolume: {
+              sum: {
+                field: 'tradedAmount',
+              },
+            },
+            tradeVolumeUSD: {
+              sum: {
+                field: 'tradedAmountUSD',
+              },
+            },
+            bucket_truncate: {
+              bucket_sort: {
+                size: limit,
+                from: startIndex,
+              },
+            },
+          },
+        },
+        tokenCount: {
+          cardinality: {
+            field: 'tokenAddress',
+          },
+        },
+      },
+    },
+  });
+
+  const { buckets } = response.body.aggregations.stats_by_token;
+  const tokenAddresses = buckets.map(bucket => bucket.key);
+  const tokens = await Token.find({ address: { $in: tokenAddresses } }).lean();
+  const tokenCount = response.body.aggregations.tokenCount.value;
+
+  const tokensWithStats = buckets.map(bucket => {
+    const token = tokens.find(t => t.address === bucket.key);
+    const imageUrl = _.get(token, 'imageUrl', null);
+
+    return {
+      address: bucket.key,
+      imageUrl: imageUrl !== null ? getCdnTokenImageUrl(imageUrl) : null,
+      name: _.get(token, 'name', 'Unknown'),
+      stats: {
+        fillCount: bucket.doc_count,
+        fillVolume: {
+          token: bucket.fillVolume.value,
+          USD: bucket.fillVolumeUSD.value,
+        },
+        tradeCount: bucket.tradeCount.value,
+        tradeVolume: {
+          token: bucket.tradeVolume.value,
+          USD: bucket.tradeVolumeUSD.value,
+        },
+      },
+      symbol: _.get(token, 'symbol', 'unknown'),
+    };
+  });
+
+  return {
+    tokens: tokensWithStats,
+    resultCount: tokenCount,
+  };
+};
+
+module.exports = getRelayersForTokenInPeriod;


### PR DESCRIPTION
This PR updates the relayer endpoint to include stats. It also adds a new endpoint for fetching traded tokens for a given relayer.