### PR TITLE
Add rates endpoint

### DIFF
--- a/src/app/routes/v1/index.js
+++ b/src/app/routes/v1/index.js
@@ -7,6 +7,7 @@ const createAssetBridgesRouter = require('./asset-bridges');
 const createFillsRouter = require('./fills');
 const createMetricsRouter = require('./metrics');
 const createProtocolsRouter = require('./protocols');
+const createRatesRouter = require('./rates');
 const createRelayerLookupRouter = require('./relayer-lookup');
 const createRelayerRouter = require('./relayer');
 const createRelayersRouter = require('./relayers');
@@ -29,6 +30,7 @@ const createRouter = () => {
     createFillsRouter().routes(),
     createMetricsRouter().routes(),
     createProtocolsRouter().routes(),
+    createRatesRouter().routes(),
     createRelayerLookupRouter().routes(),
     createRelayerRouter().routes(),
     createRelayersRouter().routes(),

--- a/src/app/routes/v1/rates.js
+++ b/src/app/routes/v1/rates.js
@@ -1,0 +1,48 @@
+const axios = require('axios');
+const moment = require('moment');
+const Router = require('koa-router');
+
+const { getLogger } = require('../../../util/logging');
+
+let lastRates;
+let lastUpdated;
+
+const getRates = async () => {
+  const stale =
+    lastRates === undefined ||
+    moment(lastUpdated)
+      .add('1', 'minutes')
+      .toDate() < new Date();
+
+  if (!stale) {
+    return lastRates;
+  }
+
+  const logger = getLogger('rates');
+  const { data } = await axios.get(
+    'https://min-api.cryptocompare.com/data/pricemulti?fsyms=USD&tsyms=AUD,BTC,GBP,CNY,ETH,EUR,JPY,KRW,USD',
+  );
+
+  lastUpdated = new Date();
+  lastRates = data;
+
+  logger.info('refreshed rates');
+
+  return lastRates;
+};
+
+const createRouter = () => {
+  const router = new Router({ prefix: '/rates' });
+
+  router.get('/', async ({ response }, next) => {
+    const rates = await getRates();
+
+    response.body = rates;
+
+    await next();
+  });
+
+  return router;
+};
+
+module.exports = createRouter;


### PR DESCRIPTION
This PR introduces a rates endpoint which acts as a proxy for calling Cryptocompare. Calling Cryptocompare from the frontend is problematic because some browser extensions intentionally block it causing 0x Tracker to fall over for users with these extensions installed.