### PR TITLE
Increase /fills max returned pages from 50 to 100

### DIFF
--- a/src/app/routes/v1/fills.js
+++ b/src/app/routes/v1/fills.js
@@ -42,7 +42,7 @@ const createRouter = () => {
     middleware.pagination({
       defaultLimit: 20,
       maxLimit: 50,
-      maxPage: 50,
+      maxPage: 100,
     }),
     middleware.number('protocolVersion'),
     middleware.number('valueFrom'),


### PR DESCRIPTION
Currently the API is not usable for most apps the max result that can be returned are 50 * 50 = 2500 fills
I'm proposing to increase it to 50 * 100, doubling the number of pages that can be browsed